### PR TITLE
Add `stats` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "jsonlrpc"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9532e8d0abaf35751b1d6210c9cc7a3648f3b59bd4ec0c1f68afbffd5ea44e4"
+checksum = "f0ea25e3461f06b4ac93e6e320cc665b0239bc6a77f54aa935174eecf1108e61"
 dependencies = [
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Usage: jlot <COMMAND>
 
 Commands:
   call             Execute a JSON-RPC call
+  stream-call      Execute a stream of JSON-RPC calls received from the standard input
   req              Generate a JSON-RPC request object JSON
+  stats            Calculate statistics from JSON objects outputted by executing the command `stream-call --add-metadata ...`
   run-echo-server  Run a JSON-RPC echo server (for development or testing purposes)
   help             Print this message or the help of the given subcommand(s)
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,7 @@
+pub fn maybe_eos<T>(result: serde_json::Result<T>) -> serde_json::Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(e) if e.io_error_kind() == Some(std::io::ErrorKind::UnexpectedEof) => Ok(None),
+        Err(e) => Err(e),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod call;
 pub mod req;
 pub mod run_echo_server;
+pub mod stats;
 pub mod stream_call;
+
+mod io;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use orfail::OrFail;
 
 use jlot::{
-    call::CallCommand, req::ReqCommand, run_echo_server::RunEchoServerCommand,
+    call::CallCommand, req::ReqCommand, run_echo_server::RunEchoServerCommand, stats::StatsCommand,
     stream_call::StreamCallCommand,
 };
 
@@ -13,6 +13,7 @@ enum Args {
     Call(CallCommand),
     StreamCall(StreamCallCommand),
     Req(ReqCommand),
+    Stats(StatsCommand),
     RunEchoServer(RunEchoServerCommand),
 }
 
@@ -22,6 +23,7 @@ fn main() -> orfail::Result<()> {
         Args::Call(c) => c.run().or_fail()?,
         Args::StreamCall(c) => c.run().or_fail()?,
         Args::Req(c) => c.run().or_fail()?,
+        Args::Stats(c) => c.run().or_fail()?,
         Args::RunEchoServer(c) => c.run().or_fail()?,
     }
     Ok(())

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,6 +5,9 @@ use serde::Serialize;
 use crate::{io, stream_call::Output};
 
 /// Calculate statistics from JSON objects outputted by executing the command `stream-call --add-metadata ...`.
+///
+/// Note that the output of `stream-call` command does not include notifications,
+/// so the statistics do not take them into account.
 #[derive(Debug, clap::Args)]
 pub struct StatsCommand {}
 
@@ -22,10 +25,38 @@ impl StatsCommand {
 }
 
 #[derive(Debug, Default, Serialize)]
-struct Stats {}
+struct Stats {
+    output_count: usize,
+    non_metadata_output_count: usize,
+    batch_output_count: usize,
+
+    ok_response_count: usize,
+    error_response_count: usize,
+
+    min_latency: f64,
+    avg_latency: f64,
+    max_latency: f64,
+
+    incoming_bps: f64,
+    outgoing_bps: f64,
+
+    incoming_bytes: usize,
+    outgoing_bytes: usize,
+}
 
 impl Stats {
     fn handle_output(&mut self, output: Output) {
-        println!("{:?}", output);
+        self.output_count += 1;
+
+        // if matches!(output.response, ResponseObject::Ok { .. }) {
+        //     self.ok_count += 1;
+        // } else {
+        //     self.error_count += 1;
+        // }
+
+        let Some(metadata) = output.metadata else {
+            self.non_metadata_output_count += 1;
+            return;
+        };
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,31 @@
+use jsonlrpc::JsonlStream;
+use orfail::OrFail;
+use serde::Serialize;
+
+use crate::{io, stream_call::Output};
+
+/// Calculate statistics from JSON objects outputted by executing the command `stream-call --add-metadata ...`.
+#[derive(Debug, clap::Args)]
+pub struct StatsCommand {}
+
+impl StatsCommand {
+    pub fn run(self) -> orfail::Result<()> {
+        let stdin = std::io::stdin();
+        let mut stream = JsonlStream::new(stdin.lock());
+        let mut stats = Stats::default();
+        while let Some(output) = io::maybe_eos(stream.read_object::<Output>()).or_fail()? {
+            stats.handle_output(output);
+        }
+        println!("{}", serde_json::to_string(&stats).or_fail()?);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+struct Stats {}
+
+impl Stats {
+    fn handle_output(&mut self, output: Output) {
+        println!("{:?}", output);
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,8 +1,13 @@
+use std::{io::Write, time::Duration};
+
 use jsonlrpc::JsonlStream;
 use orfail::OrFail;
 use serde::Serialize;
 
-use crate::{io, stream_call::Output};
+use crate::{
+    io,
+    stream_call::{Metadata, Output},
+};
 
 /// Calculate statistics from JSON objects outputted by executing the command `stream-call --add-metadata ...`.
 ///
@@ -19,6 +24,7 @@ impl StatsCommand {
         while let Some(output) = io::maybe_eos(stream.read_object::<Output>()).or_fail()? {
             stats.handle_output(output);
         }
+        stats.finalize();
         println!("{}", serde_json::to_string(&stats).or_fail()?);
         Ok(())
     }
@@ -26,37 +32,139 @@ impl StatsCommand {
 
 #[derive(Debug, Default, Serialize)]
 struct Stats {
-    output_count: usize,
-    non_metadata_output_count: usize,
-    batch_output_count: usize,
+    duration: f64,
+    max_concurrency: usize,
+    count: Counter,
+    latency: Latency,
+    bps: Bps,
 
-    ok_response_count: usize,
-    error_response_count: usize,
+    #[serde(skip)]
+    start_end_times: Vec<(Duration, Duration)>,
 
-    min_latency: f64,
-    avg_latency: f64,
-    max_latency: f64,
+    #[serde(skip)]
+    latencies: Vec<Duration>,
 
-    incoming_bps: f64,
-    outgoing_bps: f64,
+    #[serde(skip)]
+    outgoing_bytes: u64,
 
-    incoming_bytes: usize,
-    outgoing_bytes: usize,
+    #[serde(skip)]
+    incoming_bytes: u64,
 }
 
 impl Stats {
+    fn finalize(&mut self) {
+        if self.duration > 0.0 {
+            self.bps.incoming = (self.incoming_bytes * 8) as f64 / self.duration;
+            self.bps.outgoing = (self.outgoing_bytes * 8) as f64 / self.duration;
+        }
+
+        if !self.latencies.is_empty() {
+            self.latencies.sort();
+            self.latency.min = self.latencies.first().expect("unreachable").as_secs_f64();
+            self.latency.p25 = self.latencies[self.latencies.len() / 4].as_secs_f64();
+            self.latency.p50 = self.latencies[self.latencies.len() / 2].as_secs_f64();
+            self.latency.p75 = self.latencies[self.latencies.len() * 3 / 4].as_secs_f64();
+            self.latency.max = self.latencies.last().expect("unreachable").as_secs_f64();
+            self.latency.avg = (self.latencies.iter().sum::<Duration>()
+                / self.latencies.len() as u32)
+                .as_secs_f64();
+        }
+
+        self.start_end_times.sort();
+        for i in 0..self.start_end_times.len() {
+            let end = self.start_end_times[i].1;
+            let concurrency = self.start_end_times[i..]
+                .iter()
+                .take_while(|x| x.0 <= end)
+                .count();
+            self.max_concurrency = self.max_concurrency.max(concurrency);
+        }
+    }
+
     fn handle_output(&mut self, output: Output) {
-        self.output_count += 1;
+        self.count.calls += 1;
+        if output.is_batch() {
+            self.count.batch_calls += 1;
+        }
 
-        // if matches!(output.response, ResponseObject::Ok { .. }) {
-        //     self.ok_count += 1;
-        // } else {
-        //     self.error_count += 1;
-        // }
+        self.count.requests += output.len();
+        for res in output.iter() {
+            if res.response.to_std_result().is_ok() {
+                self.count.responses.ok += 1;
+            } else {
+                self.count.responses.error += 1;
+            }
+        }
 
-        let Some(metadata) = output.metadata else {
-            self.non_metadata_output_count += 1;
-            return;
-        };
+        if let Some(metadata) = output.iter().find_map(|res| res.metadata.as_ref()) {
+            self.handle_metadata(metadata, &output);
+        } else {
+            self.count.missing_metadata_calls += 1;
+        }
+    }
+
+    fn handle_metadata(&mut self, metadata: &Metadata, output: &Output) {
+        self.duration = self.duration.max(metadata.end_time.as_secs_f64());
+
+        self.start_end_times
+            .push((metadata.start_time, metadata.end_time));
+        self.latencies
+            .push(metadata.end_time.saturating_sub(metadata.start_time));
+
+        let mut bytes = Bytes::default();
+        for res in output.iter().map(|x| &x.response) {
+            serde_json::to_writer(&mut bytes, res).expect("unreachable");
+        }
+        self.incoming_bytes += bytes.0 as u64;
+
+        let mut bytes = Bytes::default();
+        serde_json::to_writer(&mut bytes, &metadata.request).expect("unreachable");
+        self.outgoing_bytes += bytes.0 as u64;
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+struct Counter {
+    calls: usize,
+    batch_calls: usize,
+    missing_metadata_calls: usize,
+
+    requests: usize,
+    responses: OkOrError,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct OkOrError {
+    ok: usize,
+    error: usize,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct Latency {
+    min: f64,
+    p25: f64,
+    p50: f64,
+    p75: f64,
+    max: f64,
+    avg: f64,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct Bps {
+    outgoing: f64,
+    incoming: f64,
+}
+
+#[derive(Debug, Default)]
+struct Bytes(usize);
+
+impl Write for Bytes {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0 += buf.len();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }

--- a/src/stream_call.rs
+++ b/src/stream_call.rs
@@ -217,31 +217,20 @@ impl ClientRunner {
         let metadata = if self.requests.is_empty() {
             None
         } else {
-            let id = match &response {
-                MaybeBatch::Single(r) => r.id(),
-                MaybeBatch::Batch(batch) => batch.first().and_then(|r| r.id()),
-            };
-            id.and_then(|id| self.requests.remove(id))
+            response
+                .iter()
+                .find_map(|r| r.response.id())
+                .and_then(|id| self.requests.remove(id))
         };
 
-        let output = if let Some(mut metadata) = metadata {
+        if let Some(mut metadata) = metadata {
             metadata.end_time = self.base_time.elapsed();
-            match &mut response {
-                MaybeBatch::Single(response) => {
-                    response.metadata = Some(metadata);
-                }
-                MaybeBatch::Batch(responses) => {
-                    if let Some(r) = responses.first_mut() {
-                        r.metadata = Some(metadata);
-                    }
-                }
+            if let Some(r) = response.iter_mut().next() {
+                r.metadata = Some(metadata);
             }
-            response
-        } else {
-            response
-        };
+        }
 
-        self.output_tx.send(output).or_fail()?;
+        self.output_tx.send(response).or_fail()?;
         self.ongoing_calls -= 1;
         Ok(())
     }
@@ -256,10 +245,7 @@ struct Input {
 
 impl Input {
     fn new(request: MaybeBatch<RequestObject>) -> Self {
-        let is_notification = match &request {
-            MaybeBatch::Single(r) => r.id.is_none(),
-            MaybeBatch::Batch(rs) => rs.iter().all(|r| r.id.is_none()),
-        };
+        let is_notification = request.iter().all(|r| r.id.is_none());
         Self {
             request,
             is_notification,
@@ -272,23 +258,12 @@ impl Input {
             return;
         }
 
-        match &mut self.request {
-            MaybeBatch::Single(r) => {
-                r.id = Some(RequestId::Number(*next_id));
+        for r in self.request.iter_mut().filter(|r| r.id.is_some()) {
+            r.id = Some(RequestId::Number(*next_id));
+            if self.metadata_id.is_none() {
                 self.metadata_id = r.id.clone();
-                *next_id += 1;
             }
-            MaybeBatch::Batch(batch) => {
-                for r in batch {
-                    if r.id.is_some() {
-                        r.id = Some(RequestId::Number(*next_id));
-                        if self.metadata_id.is_none() {
-                            self.metadata_id = r.id.clone();
-                        }
-                        *next_id += 1;
-                    }
-                }
-            }
+            *next_id += 1;
         }
     }
 }
@@ -302,15 +277,6 @@ pub struct ResponseWithMetadata {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
-}
-
-impl ResponseWithMetadata {
-    fn id(&self) -> Option<&RequestId> {
-        match &self.response {
-            ResponseObject::Ok { id, .. } => Some(id),
-            ResponseObject::Err { id, .. } => id.as_ref(),
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Copilot Summary
------------------

This pull request introduces several new features and improvements to the JSON-RPC tool. The most significant changes include adding a new `stats` command, refactoring the `call` command to handle notifications more effectively, and introducing a utility function for handling end-of-stream scenarios.

### New Features:
* **New `stats` Command**: Added a new command to calculate statistics from JSON objects outputted by the `stream-call` command. This includes detailed statistics such as duration, concurrency, request counts, and latency metrics. (`README.md`, `src/lib.rs`, `src/main.rs`, `src/stats.rs`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R26) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R4-R7) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL5-R5) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR16) [[5]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR26) [[6]](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aR1-R170)

### Refactoring and Improvements:
* **Refactored `call` Command**: Modified the `call` command to handle notifications more effectively by checking if any request IDs are present and using appropriate methods for notifications and calls. (`src/call.rs`)
* **Utility Function for End-of-Stream**: Added a new utility function `maybe_eos` to handle end-of-stream scenarios gracefully. (`src/io.rs`, `src/stream_call.rs`) [[1]](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R1-R7) [[2]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L69-R71) [[3]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L213-L247)

### Codebase Simplification:
* **Simplified `Input` Struct**: Refactored the `Input` struct to simplify the logic for determining if a request is a notification and reassigning IDs. (`src/stream_call.rs`) [[1]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L257-R248) [[2]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L273-R261) [[3]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L290-R287)

### Minor Enhancements:
* **Updated Imports**: Added necessary imports for the new `stats` module and updated existing imports for better organization. (`src/main.rs`, `src/stream_call.rs`) [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL5-R5) [[2]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L11-R13)

These changes collectively enhance the functionality and maintainability of the JSON-RPC tool.