### PR TITLE
Fix minor bugs and add `--count` option to `req` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Options:
 Examples
 --------
 
+### Basic RPC call
+
 Start an echo server in a terminal:
 ```console
 $ jlot run-echo-server 127.0.0.1:9000
@@ -54,5 +56,47 @@ $ jlot call 127.0.0.1:9000 $(jlot req hello '["world"]' --id 2) | jq .
     ]
   },
   "id": 2
+}
+```
+
+### Benchmarking
+
+Start an echo server in a terminal:
+```console
+$ jlot run-echo-server 127.0.0.1:9000
+```
+
+Execute 1000 RPC calls with pipelining enabled and gather the statistics:
+```console
+$ jlot req put --id 0 --count 1000 | \
+    jlot stream-call 127.0.0.1:9000 --pipelining 10 --add-metadata | \
+    jlot stats | \
+    jq .
+{
+  "duration": 0.378478,
+  "max_concurrency": 10,
+  "count": {
+    "calls": 1000,
+    "batch_calls": 0,
+    "missing_metadata_calls": 0,
+    "requests": 1000,
+    "responses": {
+      "ok": 1000,
+      "error": 0
+    }
+  },
+  "rps": 2642.1614994794945,
+  "bps": {
+    "outgoing": 864303.8697097321,
+    "incoming": 1622921.2794402845
+  },
+  "latency": {
+    "min": 9.525e-05,
+    "p25": 0.000223541,
+    "p50": 0.0003005,
+    "p75": 0.010511875,
+    "max": 0.012503042,
+    "avg": 0.003430977
+  }
 }
 ```

--- a/src/call.rs
+++ b/src/call.rs
@@ -29,7 +29,7 @@ impl CallCommand {
             socket.set_nodelay(true).or_fail()?;
             let mut client = RpcClient::new(socket);
 
-            let is_notification = self.request.iter().any(|r| r.id.is_some());
+            let is_notification = self.request.iter().all(|r| r.id.is_none());
             match is_notification {
                 true => {
                     client.cast(&self.request).or_fail()?;

--- a/src/req.rs
+++ b/src/req.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use jsonlrpc::{JsonRpcVersion, RequestId, RequestObject, RequestParams};
 use orfail::OrFail;
 
@@ -15,6 +17,9 @@ pub struct ReqCommand {
     /// If not provided, the request is regarded as a notification.
     #[clap(long)]
     id: Option<RequestId>,
+
+    #[clap(short, long, default_value = "1")]
+    count: NonZeroUsize,
 }
 
 impl ReqCommand {
@@ -25,7 +30,11 @@ impl ReqCommand {
             params: self.params,
             id: self.id,
         };
-        println!("{}", serde_json::to_string(&request).or_fail()?);
+
+        let json = serde_json::to_string(&request).or_fail()?;
+        for _ in 0..self.count.get() {
+            println!("{json}");
+        }
         Ok(())
     }
 }

--- a/src/req.rs
+++ b/src/req.rs
@@ -25,7 +25,7 @@ impl ReqCommand {
             params: self.params,
             id: self.id,
         };
-        serde_json::to_writer(std::io::stdout(), &request).or_fail()?;
+        println!("{}", serde_json::to_string(&request).or_fail()?);
         Ok(())
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -72,11 +72,16 @@ impl Stats {
 
         self.start_end_times.sort();
         for i in 0..self.start_end_times.len() {
-            let end = self.start_end_times[i].1;
-            let concurrency = self.start_end_times[i..]
+            let (start, end) = self.start_end_times[i];
+            let concurrency = self.start_end_times[..i]
                 .iter()
-                .take_while(|x| x.0 <= end)
-                .count();
+                .rev()
+                .take_while(|x| start < x.1)
+                .count()
+                + self.start_end_times[i..]
+                    .iter()
+                    .take_while(|x| x.0 < end)
+                    .count();
             self.max_concurrency = self.max_concurrency.max(concurrency);
         }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -35,8 +35,9 @@ struct Stats {
     duration: f64,
     max_concurrency: usize,
     count: Counter,
-    latency: Latency,
+    rps: f64,
     bps: Bps,
+    latency: Latency,
 
     #[serde(skip)]
     start_end_times: Vec<(Duration, Duration)>,
@@ -71,6 +72,8 @@ impl Stats {
         if self.duration > 0.0 {
             self.bps.incoming = (self.incoming_bytes * 8) as f64 / self.duration;
             self.bps.outgoing = (self.outgoing_bytes * 8) as f64 / self.duration;
+
+            self.rps = self.count.requests as f64 / self.duration;
         }
 
         if !self.latencies.is_empty() {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -90,16 +90,12 @@ impl Stats {
 
         self.start_end_times.sort();
         for i in 0..self.start_end_times.len() {
-            let (start, end) = self.start_end_times[i];
+            let (start, _end) = self.start_end_times[i];
             let concurrency = self.start_end_times[..i]
                 .iter()
                 .rev()
                 .take_while(|x| start < x.1)
-                .count()
-                + self.start_end_times[i..]
-                    .iter()
-                    .take_while(|x| x.0 < end)
-                    .count();
+                .count();
             self.max_concurrency = self.max_concurrency.max(concurrency);
         }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -95,7 +95,8 @@ impl Stats {
                 .iter()
                 .rev()
                 .take_while(|x| start < x.1)
-                .count();
+                .count()
+                + 1;
             self.max_concurrency = self.max_concurrency.max(concurrency);
         }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -53,6 +53,21 @@ struct Stats {
 
 impl Stats {
     fn finalize(&mut self) {
+        self.duration = self
+            .start_end_times
+            .iter()
+            .map(|(_, end)| *end)
+            .max()
+            .unwrap_or_default()
+            .saturating_sub(
+                self.start_end_times
+                    .iter()
+                    .map(|(start, _)| *start)
+                    .min()
+                    .unwrap_or_default(),
+            )
+            .as_secs_f64();
+
         if self.duration > 0.0 {
             self.bps.incoming = (self.incoming_bytes * 8) as f64 / self.duration;
             self.bps.outgoing = (self.outgoing_bytes * 8) as f64 / self.duration;
@@ -109,8 +124,6 @@ impl Stats {
     }
 
     fn handle_metadata(&mut self, metadata: &Metadata, output: &Output) {
-        self.duration = self.duration.max(metadata.end_time.as_secs_f64());
-
         self.start_end_times
             .push((metadata.start_time, metadata.end_time));
         self.latencies


### PR DESCRIPTION
This pull request includes several changes to the `README.md` and various Rust source files to enhance functionality and improve documentation. The most important changes include adding new documentation sections, modifying the behavior of RPC requests, and updating the statistics calculation.

Documentation improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R39): Added sections for "Basic RPC call" and "Benchmarking" to provide examples and usage instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R102)

Code functionality updates:

* [`src/call.rs`](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL32-R32): Changed the `is_notification` logic to correctly identify notifications by checking that all request IDs are `None`.
* [`src/req.rs`](diffhunk://#diff-c398fbdf771e1efd8e70784b3bd887fd15bcd12494910b309909bdaada9bb77cR1-R2): Introduced a new `count` parameter in `ReqCommand` to allow multiple requests to be generated and printed. [[1]](diffhunk://#diff-c398fbdf771e1efd8e70784b3bd887fd15bcd12494910b309909bdaada9bb77cR1-R2) [[2]](diffhunk://#diff-c398fbdf771e1efd8e70784b3bd887fd15bcd12494910b309909bdaada9bb77cR20-R22) [[3]](diffhunk://#diff-c398fbdf771e1efd8e70784b3bd887fd15bcd12494910b309909bdaada9bb77cL28-R37)

Statistics calculation enhancements:

* [`src/stats.rs`](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aL38-R40): Added `rps` (requests per second) to the `Stats` struct and updated the `finalize` method to calculate `duration` and `rps`. Improved concurrency calculation in `finalize`. [[1]](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aL38-R40) [[2]](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aR57-R76) [[3]](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aL75-R99) [[4]](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aL107-L108)