### PR TITLE
Fix typo: s/local_addr/peer_addr/

### DIFF
--- a/src/stream_call.rs
+++ b/src/stream_call.rs
@@ -45,7 +45,7 @@ impl StreamCallCommand {
             let (input_tx, input_rx) = mpsc::sync_channel(pipelining * 2 + 10);
             let output_tx = output_tx.clone();
             let runner = ClientRunner {
-                server_addr: stream.inner().local_addr().or_fail()?,
+                server_addr: stream.inner().peer_addr().or_fail()?,
                 stream,
                 base_time,
                 input_rx,


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request includes a change to the `StreamCallCommand` implementation in the `src/stream_call.rs` file. The change corrects the assignment of the `server_addr` field in the `ClientRunner` struct.

* [`src/stream_call.rs`](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L48-R48): Modified the `server_addr` field to use `peer_addr` instead of `local_addr` in the `ClientRunner` struct.