### PR TITLE
Add `--dry-run` option to `stream-call` command

### DIFF
--- a/src/stream_call.rs
+++ b/src/stream_call.rs
@@ -33,6 +33,9 @@ pub struct StreamCallCommand {
     #[clap(long)]
     preread: bool,
 
+    /// Run the command without connecting to or communicating with actual servers.
+    ///
+    /// All RPC responses will be set to `null`.
     #[clap(long)]
     dry_run: bool,
 }


### PR DESCRIPTION
Copilot Summary
-------------------

This pull request introduces a new feature to the `StreamCallCommand` struct in the `src/stream_call.rs` file, allowing for a dry run mode. The dry run mode enables the system to simulate the maximum performance without actually communicating with the servers. The most important changes include the addition of the `dry_run` field, modifications to handle dry run logic, and the implementation of a new `ClientDryRunner` struct.

Key changes:

* Added `dry_run` field to `StreamCallCommand`:
  - Introduced a new field `dry_run` in the `StreamCallCommand` struct to enable dry run mode.

* Modified `connect_to_servers` method:
  - Updated the `connect_to_servers` method to return a tuple containing the server address and an optional `JsonlStream`. This allows the method to handle both regular and dry run modes.

* Updated stream handling logic:
  - Adjusted the loop that processes streams to handle the case where a stream is `None` (indicating a dry run). If in dry run mode, it spawns a `ClientDryRunner` instead of a `ClientRunner`. [[1]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L44-R50) [[2]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2R67-R83)

* Introduced `ClientDryRunner` struct:
  - Added the `ClientDryRunner` struct, which simulates sending requests and receiving responses without actual network communication. This struct includes methods for running the simulation, sending requests, and receiving responses.

* Added `VecDeque` to imports:
  - Included `VecDeque` in the imports to support the new `ClientDryRunner` struct.