### PR TITLE
Add `--concurrency` option instead of `--pipelining`

### DIFF
--- a/src/stream_call.rs
+++ b/src/stream_call.rs
@@ -132,7 +132,7 @@ impl StreamCallCommand {
                             next_thread_index = (next_thread_index + 1) % input_txs.len();
                             retried_count += 1;
                             if retried_count == input_txs.len() {
-                                std::thread::sleep(Duration::from_millis(10));
+                                //std::thread::sleep(Duration::from_millis(1));
                                 retried_count = 0;
                             }
                             continue;
@@ -178,14 +178,16 @@ impl StreamCallCommand {
         let servers = 1 + self.additional_server_addrs.len();
         let pipelining = self.concurrency.get() / servers;
         let mut remainings = self.concurrency.get() % servers;
-        (0..servers).map(move |_| {
-            if remainings > 0 {
-                remainings -= 1;
-                pipelining + 1
-            } else {
-                pipelining
-            }
-        })
+        (0..servers)
+            .map(move |_| {
+                if remainings > 0 {
+                    remainings -= 1;
+                    pipelining + 1
+                } else {
+                    pipelining
+                }
+            })
+            .take_while(|pipelining| *pipelining > 0)
     }
 }
 


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes several changes to the `StreamCallCommand` struct and its implementation in the `src/stream_call.rs` file. The changes focus on renaming a field, adjusting concurrency logic, and modifying the behavior of a retry mechanism.

Key changes include:

* **Field Renaming:**
  * Renamed the `pipelining` field to `concurrency` in the `StreamCallCommand` struct to better reflect its purpose.

* **Concurrency Logic Adjustment:**
  * Updated the loop in the `StreamCallCommand` implementation to use the new `concurrency` field and a new method `pipelinings()` to determine the number of concurrent calls for each server. [[1]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L58-R60) [[2]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2R176-R191)

* **Retry Mechanism Modification:**
  * Commented out the `std::thread::sleep(Duration::from_millis(10))` line in the retry mechanism to potentially reduce the waiting time between retries.