### PR TITLE
Use `spmc` to improve `stream-call` performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "orfail",
  "serde",
  "serde_json",
+ "spmc",
 ]
 
 [[package]]
@@ -203,6 +204,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "spmc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ jsonlrpc = "0.2.0"
 orfail = "1.1.0"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
+spmc = "0.3.0"


### PR DESCRIPTION
Copilot Summary
------------------

This pull request introduces several changes to improve the concurrency handling in the `StreamCallCommand` by switching from `mpsc` to `spmc` channels. Additionally, it removes some redundant code and simplifies the error handling logic.

Concurrency improvements:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R18): Added the `spmc` crate to the dependencies.
* [`src/stream_call.rs`](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L190-R171): Replaced `mpsc::Receiver` with `spmc::Receiver` in `ClientRunner` and `ClientDryRunner` structs to allow multiple consumers. [[1]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L190-R171) [[2]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L324-R303)
* [`src/stream_call.rs`](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2R57-R67): Updated the channel creation to use `spmc::channel` instead of `mpsc::sync_channel` for input transmission.

Code simplification:

* [`src/stream_call.rs`](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L46): Removed the `input_txs` vector and related logic, simplifying the input sending mechanism. [[1]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L46) [[2]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L97-L103) [[3]](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L125-R125)

Error handling adjustments:

* [`src/stream_call.rs`](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L125-R125): Simplified error handling by removing the retry loop for sending inputs and handling the send result directly.

These changes collectively enhance the performance and maintainability of the `StreamCallCommand` implementation.