### PR TITLE
Add `--notification` option to `call` command

### DIFF
--- a/src/req.rs
+++ b/src/req.rs
@@ -13,11 +13,14 @@ pub struct ReqCommand {
     params: Option<RequestParams>,
 
     /// Request ID (number or string).
-    ///
-    /// If not provided, the request is regarded as a notification.
-    #[clap(long)]
-    id: Option<RequestId>,
+    #[clap(long, short, default_value = "0")]
+    id: RequestId,
 
+    /// When set, the "id" field will be excluded from the resulting JSON object.
+    #[clap(short, long)]
+    notification: bool,
+
+    /// Count of requests to generate.
     #[clap(short, long, default_value = "1")]
     count: NonZeroUsize,
 }
@@ -28,7 +31,7 @@ impl ReqCommand {
             jsonrpc: JsonRpcVersion::V2,
             method: self.method,
             params: self.params,
-            id: self.id,
+            id: (!self.notification).then_some(self.id),
         };
 
         let json = serde_json::to_string(&request).or_fail()?;


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes changes to the `ReqCommand` structure in the `src/req.rs` file to enhance its functionality and flexibility. The most important changes include modifying the handling of the `id` field, adding a new `notification` field, and updating the request generation logic.

Enhancements to `ReqCommand` structure:

* [`src/req.rs`](diffhunk://#diff-c398fbdf771e1efd8e70784b3bd887fd15bcd12494910b309909bdaada9bb77cL16-R23): Changed the `id` field to always have a default value of "0" and added a new `notification` field to determine whether the `id` field should be included in the resulting JSON object.

Updates to request generation logic:

* [`src/req.rs`](diffhunk://#diff-c398fbdf771e1efd8e70784b3bd887fd15bcd12494910b309909bdaada9bb77cL31-R34): Updated the `id` assignment logic in the `impl ReqCommand` block to conditionally include the `id` field based on the value of the `notification` field.