### PR TITLE
Make the hostname in a server address able to be abbreviated

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -17,7 +17,11 @@ pub struct CallCommand {
 }
 
 impl CallCommand {
-    pub fn run(self) -> orfail::Result<()> {
+    pub fn run(mut self) -> orfail::Result<()> {
+        if self.server_addr.starts_with(':') {
+            self.server_addr = format!("127.0.0.1{}", self.server_addr);
+        }
+
         let socket = TcpStream::connect(&self.server_addr)
             .or_fail_with(|e| format!("Failed to connect to '{}': {e}", self.server_addr))?;
         socket.set_nodelay(true).or_fail()?;

--- a/src/stream_call.rs
+++ b/src/stream_call.rs
@@ -134,7 +134,12 @@ impl StreamCallCommand {
             if self.dry_run {
                 streams.push(None);
             } else {
-                let socket = TcpStream::connect(server)
+                let server = if server.starts_with(':') {
+                    format!("127.0.0.1{server}")
+                } else {
+                    server.to_owned()
+                };
+                let socket = TcpStream::connect(&server)
                     .or_fail_with(|e| format!("Failed to connect to '{server}': {e}"))?;
                 socket.set_nodelay(true).or_fail()?;
                 streams.push(Some(JsonlStream::new(socket)));


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes changes to the `src/call.rs` and `src/stream_call.rs` files to improve the handling of server addresses. Specifically, it ensures that server addresses starting with a colon are prefixed with `127.0.0.1`.

Improvements to server address handling:

* [`src/call.rs`](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL20-R24): Modified the `run` method in the `CallCommand` struct to check if `server_addr` starts with a colon and prepend `127.0.0.1` if necessary.
* [`src/stream_call.rs`](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L137-R142): Updated the `StreamCallCommand` implementation to handle server addresses starting with a colon by prepending `127.0.0.1`.