### PR TITLE
Fix an error if the server hostname is abbreviated in dry-run mode

### DIFF
--- a/src/stream_call.rs
+++ b/src/stream_call.rs
@@ -134,11 +134,6 @@ impl StreamCallCommand {
             if self.dry_run {
                 streams.push(None);
             } else {
-                let server = if server.starts_with(':') {
-                    format!("127.0.0.1{server}")
-                } else {
-                    server.to_owned()
-                };
                 let socket = TcpStream::connect(&server)
                     .or_fail_with(|e| format!("Failed to connect to '{server}': {e}"))?;
                 socket.set_nodelay(true).or_fail()?;
@@ -148,8 +143,16 @@ impl StreamCallCommand {
         Ok(streams)
     }
 
-    fn servers(&self) -> impl '_ + Iterator<Item = &String> {
-        std::iter::once(&self.server_addr).chain(self.additional_server_addrs.iter())
+    fn servers(&self) -> impl '_ + Iterator<Item = String> {
+        std::iter::once(&self.server_addr)
+            .chain(self.additional_server_addrs.iter())
+            .map(|s| {
+                if s.starts_with(':') {
+                    format!("127.0.0.1{s}")
+                } else {
+                    s.to_owned()
+                }
+            })
     }
 
     fn pipelinings(&self) -> impl Iterator<Item = usize> {


### PR DESCRIPTION
Copilot Summary
-------------------

This pull request includes changes to the `StreamCallCommand` implementation in the `src/stream_call.rs` file. The changes focus on improving the handling of server addresses and simplifying the code.

Changes to server address handling:

* Removed the conditional formatting of the `server` variable within the `connect` block and moved it to the `servers` method. This ensures that all server addresses are formatted consistently before being used.

Code simplification:

* Modified the `servers` method to return an iterator of formatted server addresses. This change consolidates the address formatting logic, making the code more maintainable and readable.