### PR TITLE
Rename `--pre-read` option to `--buffer-input`

### DIFF
--- a/src/stream_call.rs
+++ b/src/stream_call.rs
@@ -30,8 +30,8 @@ pub struct StreamCallCommand {
     add_metadata: bool,
 
     /// Read the entire standard input stream before sending any requests.
-    #[clap(long)]
-    preread: bool,
+    #[clap(short, long)]
+    buffer_input: bool,
 
     /// Run the command without connecting to or communicating with actual servers.
     ///
@@ -101,14 +101,14 @@ impl StreamCallCommand {
         let mut next_id = 0;
 
         let mut inputs = Vec::new();
-        if self.preread {
+        if self.buffer_input {
             while let Some(request) = io::maybe_eos(input_stream.read_value()).or_fail()? {
                 inputs.push(Input::new(request));
             }
             inputs.reverse();
         }
 
-        while let Some(mut input) = if self.preread {
+        while let Some(mut input) = if self.buffer_input {
             inputs.pop()
         } else {
             io::maybe_eos(input_stream.read_value())


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request includes changes to the `StreamCallCommand` struct and its implementation in the `src/stream_call.rs` file. The most important changes involve renaming a field and updating the corresponding logic.

Renaming and updating logic:

* Renamed the `preread` field to `buffer_input` and updated its attributes to accept both short and long command-line options. (`src/stream_call.rs`, [src/stream_call.rsL33-R34](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L33-R34))
* Updated the logic within the `impl StreamCallCommand` to use `buffer_input` instead of `preread` for determining whether to read the entire standard input stream before sending requests. (`src/stream_call.rs`, [src/stream_call.rsL104-R111](diffhunk://#diff-c89492aea03c0d38dcaa79ea05b0aaff8b148e7a1366ace0d52c6e25f19fe6b2L104-R111))