### PR TITLE
Update stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,9 @@ $ jlot req put --count 100000 | \
     jlot stats | \
     jq .
 {
+  "rpc_calls": 100000,
   "duration": 0.608289541,
   "max_concurrency": 10,
-  "count": {
-    "calls": 100000,
-    "batch_calls": 0,
-    "missing_metadata_calls": 0,
-    "requests": 100000,
-    "responses": {
-      "ok": 100000,
-      "error": 0
-    }
-  },
   "rps": 164395.39604051816,
   "bps": {
     "outgoing": 56405901.60993743,

--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ $ jlot req put --count 100000 | \
   "duration": 0.608289541,
   "max_concurrency": 10,
   "rps": 164395.39604051816,
-  "bps": {
-    "outgoing": 56405901.60993743,
-    "incoming": 106235987.37825413
-  },
   "latency": {
     "min": 0.000016416,
     "p25": 0.0000435,


### PR DESCRIPTION
Copilot Summary
------------------

This pull request introduces changes to the statistics command in the `src/stats.rs` file, adding optional fields to the resulting JSON object and updating the handling of RPC calls and bytes per second (bps). Additionally, the `README.md` file has been updated to reflect these changes.

Enhancements to statistics command:

* [`src/stats.rs`](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aL17-R37): Added optional fields `count` and `bps` to the `StatsCommand` struct, allowing these fields to be included in the resulting JSON object when specified.
* [`src/stats.rs`](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aR49-R56): Updated the `Stats` struct to conditionally include the `count` and `bps` fields only if they are set.
* [`src/stats.rs`](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aL73-R95): Modified the calculation of `rps` to use the `rpc_calls` field and updated the handling of `bps` to check if the field is set before performing calculations.
* [`src/stats.rs`](diffhunk://#diff-0e692e133bf2b1fcf6a0d97c4db8aaafe11090170dc1c4d1a655cd143fcd814aL105-L122): Updated the `handle_output` method to increment the `rpc_calls` field and conditionally update the `count` field if it is set.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-L91): Updated the example output to reflect the changes in the statistics command, removing the `count` and `bps` fields from the default output.