### PR TITLE
Remove the `--buffer-input` option and enable buffering by default.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,6 @@ dependencies = [
  "orfail",
  "serde",
  "serde_json",
- "spmc",
 ]
 
 [[package]]
@@ -204,12 +203,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "spmc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ jsonlrpc = "0.2.0"
 orfail = "1.1.0"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.127"
-spmc = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Command-line tool for JSON-RPC 2.0 over JSON Lines over TCP
 Usage: jlot <COMMAND>
 
 Commands:
-  call             Execute a stream of JSON-RPC calls received from the standard input
+  call             Read JRON-RPC requests from standard input and execute the RPC calls
   req              Generate a JSON-RPC request object JSON
   stats            Calculate statistics from JSON objects outputted by executing the command `call --add-metadata ...`
   run-echo-server  Run a JSON-RPC echo server (for development or testing purposes)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ jlot run-echo-server :9000
 Execute 1000 RPC calls with pipelining enabled and gather the statistics:
 ```console
 $ jlot req put --count 100000 | \
-    jlot call :9000 --concurrency 10 --add-metadata --buffer-input | \
+    jlot call :9000 --concurrency 10 --add-metadata | \
     jlot stats | \
     jq .
 {

--- a/src/call.rs
+++ b/src/call.rs
@@ -2,7 +2,10 @@ use std::{
     collections::{HashMap, VecDeque},
     net::{SocketAddr, TcpStream},
     num::NonZeroUsize,
-    sync::mpsc::{self, RecvError},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc, Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -29,10 +32,6 @@ pub struct CallCommand {
     #[clap(short, long)]
     add_metadata: bool,
 
-    /// Read the entire standard input stream before sending any requests.
-    #[clap(short, long)]
-    buffer_input: bool,
-
     /// Run the command without connecting to or communicating with actual servers.
     ///
     /// All RPC responses will be set to `null`.
@@ -56,14 +55,18 @@ impl CallCommand {
         let stdin = std::io::stdin();
         let mut input_stream = JsonlStream::new(stdin.lock());
         let mut inputs = Vec::new();
-        if self.buffer_input {
-            while let Some(request) = io::maybe_eos(input_stream.read_value()).or_fail()? {
-                inputs.push(Input::new(request));
+        let mut next_id = 0;
+        while let Some(request) = io::maybe_eos(input_stream.read_value()).or_fail()? {
+            let mut input = Input::new(request);
+            if self.add_metadata {
+                input.reassign_id(&mut next_id);
             }
-            inputs.reverse();
+            inputs.push(input);
         }
 
-        let (mut input_tx, input_rx) = spmc::channel();
+        let inputs = Arc::new(inputs);
+        let input_index = Arc::new(AtomicUsize::new(0));
+
         let base_time = Instant::now();
         for ((server_addr, stream), pipelining) in
             self.servers().zip(streams).zip(self.pipelinings())
@@ -74,7 +77,8 @@ impl CallCommand {
                     server_addr: stream.inner().peer_addr().or_fail()?,
                     stream,
                     base_time,
-                    input_rx: input_rx.clone(),
+                    inputs: inputs.clone(),
+                    input_index: input_index.clone(),
                     output_tx,
                     pipelining,
                     ongoing_calls: 0,
@@ -90,7 +94,8 @@ impl CallCommand {
                 let runner = ClientDryRunner {
                     server_addr: server_addr.0.parse::<SocketAddr>().or_fail()?,
                     base_time,
-                    input_rx: input_rx.clone(),
+                    inputs: inputs.clone(),
+                    input_index: input_index.clone(),
                     output_tx,
                     pipelining,
                     ongoing_calls: 0,
@@ -105,22 +110,7 @@ impl CallCommand {
             }
         }
 
-        let mut next_id = 0;
-        while let Some(mut input) = if self.buffer_input {
-            inputs.pop()
-        } else {
-            io::maybe_eos(input_stream.read_value())
-                .or_fail()?
-                .map(Input::new)
-        } {
-            if self.add_metadata {
-                input.reassign_id(&mut next_id);
-            }
-
-            let _ = input_tx.send(input);
-        }
         std::mem::drop(output_tx);
-        std::mem::drop(input_tx);
         let _ = output_thread.join();
 
         Ok(())
@@ -166,7 +156,8 @@ struct ClientRunner {
     stream: JsonlStream<TcpStream>,
     server_addr: SocketAddr,
     base_time: Instant,
-    input_rx: spmc::Receiver<Input>,
+    inputs: Arc<Vec<Input>>,
+    input_index: Arc<AtomicUsize>,
     output_tx: mpsc::Sender<Output>,
     pipelining: usize,
     ongoing_calls: usize,
@@ -181,19 +172,15 @@ impl ClientRunner {
 
     fn run_one(&mut self) -> orfail::Result<bool> {
         while self.ongoing_calls < self.pipelining {
-            match self.input_rx.recv() {
-                Ok(input) => {
-                    self.send_request(input).or_fail()?;
-                }
-                Err(RecvError) => {
-                    if self.ongoing_calls == 0 {
-                        return Ok(false);
-                    }
-                    break;
-                }
+            let i = self.input_index.fetch_add(1, Ordering::SeqCst);
+            if i < self.inputs.len() {
+                self.send_request(self.inputs[i].clone()).or_fail()?;
+            } else if self.ongoing_calls == 0 {
+                return Ok(false);
+            } else {
+                break;
             }
         }
-
         self.recv_response().or_fail()?;
         Ok(true)
     }
@@ -244,7 +231,7 @@ impl ClientRunner {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Input {
     request: MaybeBatch<RequestObject>,
     is_notification: bool,
@@ -298,7 +285,8 @@ pub struct Metadata {
 struct ClientDryRunner {
     server_addr: SocketAddr,
     base_time: Instant,
-    input_rx: spmc::Receiver<Input>,
+    inputs: Arc<Vec<Input>>,
+    input_index: Arc<AtomicUsize>,
     output_tx: mpsc::Sender<Output>,
     pipelining: usize,
     ongoing_calls: usize,
@@ -313,19 +301,15 @@ impl ClientDryRunner {
 
     fn run_one(&mut self) -> orfail::Result<bool> {
         while self.ongoing_calls < self.pipelining {
-            match self.input_rx.recv() {
-                Ok(input) => {
-                    self.send_request(input);
-                }
-                Err(RecvError) => {
-                    if self.ongoing_calls == 0 {
-                        return Ok(false);
-                    }
-                    break;
-                }
+            let i = self.input_index.fetch_add(1, Ordering::SeqCst);
+            if i < self.inputs.len() {
+                self.send_request(self.inputs[i].clone());
+            } else if self.ongoing_calls == 0 {
+                return Ok(false);
+            } else {
+                break;
             }
         }
-
         self.recv_response().or_fail()?;
         Ok(true)
     }

--- a/src/call.rs
+++ b/src/call.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{io, types::ServerAddr};
 
-/// Execute a stream of JSON-RPC calls received from the standard input.
+/// Read JRON-RPC requests from standard input and execute the RPC calls.
 #[derive(Debug, clap::Args)]
 pub struct CallCommand {
     /// JSON-RPC server address or hostname.


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request includes several changes to improve the functionality and documentation of the JSON-RPC command-line tool. The most important changes include the removal of the `buffer_input` option, updates to the `README.md` file, and significant refactoring of the `CallCommand` implementation to use atomic operations and shared references for managing input data.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23): Updated the description of the `call` command and removed references to the `--buffer-input` option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R71)

### Codebase Refactoring:
* [`src/call.rs`](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL32-L35): Removed the `buffer_input` option from the `CallCommand` struct and its associated logic. [[1]](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL32-L35) [[2]](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL59-R69) [[3]](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL108-L123)
* [`src/call.rs`](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL169-R160): Refactored the `ClientRunner` and `ClientDryRunner` structs to use `Arc` and `AtomicUsize` for managing input data, replacing the previous `spmc` channel approach. [[1]](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL169-R160) [[2]](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL184-L196) [[3]](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL301-R289) [[4]](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL316-L328)

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L18): Removed the `spmc` dependency as it is no longer needed.