### PR TITLE
Allow JSON values without newline delimiters as input for the `call` command.

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -53,10 +53,13 @@ impl CallCommand {
         });
 
         let stdin = std::io::stdin();
-        let mut input_stream = JsonlStream::new(stdin.lock());
+        let input_stream = serde_json::Deserializer::from_reader(stdin.lock());
         let mut inputs = Vec::new();
         let mut next_id = 0;
-        while let Some(request) = io::maybe_eos(input_stream.read_value()).or_fail()? {
+        for request in input_stream.into_iter() {
+            let Some(request) = io::maybe_eos(request).or_fail()? else {
+                break;
+            };
             let mut input = Input::new(request);
             if self.add_metadata {
                 input.reassign_id(&mut next_id);


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes changes to the `CallCommand` implementation in `src/call.rs` to improve the handling of input streams. The most important change is the replacement of `JsonlStream` with `serde_json::Deserializer` for reading input.

Codebase simplification:

* [`src/call.rs`](diffhunk://#diff-3027e9d9c70a9fd580b45e96eb54da2772b44074adbfbd11e7d1bcaf099b8b3fL56-R62): Replaced `JsonlStream` with `serde_json::Deserializer` for reading input streams, simplifying the code and improving readability.