### PR TITLE
Add pretty-print JSON option to call command

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -45,7 +45,7 @@ impl Request {
         let mut has_method = false;
         let mut id = None;
         for (name, value) in value.to_object()? {
-            match name.as_string_str()?.as_ref() {
+            match name.as_string_str()? {
                 "jsonrpc" => {
                     if value.as_string_str()? != "2.0" {
                         return Err(value.invalid("jsonrpc version must be '2.0'"));
@@ -120,7 +120,7 @@ impl Response {
         let mut has_result_or_error = false;
 
         for (name, value) in value.to_object()? {
-            match name.as_string_str()?.as_ref() {
+            match name.as_string_str()? {
                 "jsonrpc" => {
                     if value.as_string_str()? != "2.0" {
                         return Err(value.invalid("jsonrpc version must be '2.0'"));


### PR DESCRIPTION
This PR adds a new `--pretty` / `-p` flag to the call command that enables formatted JSON output with 2-space indentation and spacing. When the flag is enabled, responses are pretty-printed using the `nojson` library; otherwise, they're output as compact JSON as before.

The implementation:
- Adds a `pretty: bool` field to `CallCommand` struct
- Introduces a new `write_response()` method to handle both compact and pretty-printed output
- Replaces direct `writeln!` calls with calls to the new method in both TCP and UDP code paths
